### PR TITLE
target property conflict with elasticsearch indexing fixed

### DIFF
--- a/Configuration/NodeTypes.Content.Section.Spotlight.Item.yaml
+++ b/Configuration/NodeTypes.Content.Section.Spotlight.Item.yaml
@@ -54,7 +54,7 @@
           group: anchor
           editor: 'Neos.Neos/Inspector/Editors/LinkEditor'
 
-    target:
+    linkTarget:
       type: boolean
       ui:
         label: 'Open In New window'

--- a/Resources/Private/Fusion/Content/Section/Spotlight.Item.fusion
+++ b/Resources/Private/Fusion/Content/Section/Spotlight.Item.fusion
@@ -48,7 +48,7 @@ prototype(Sitegeist.NeosTemplate.Spectral:Content.Section.Spotlight.Item) < prot
     href.@if.inBackend = ${node.context.live}
     href.@process.convertUris = Neos.Neos:ConvertUris
 
-    target = ${q(node).property('target')}
+    target = ${q(node).property('linkTarget')}
 
     alignment = ${q(node).property('alignment')}
 


### PR DESCRIPTION
target Property in NodeTypes.Content.Section.Spotlight.Item produces conflict with properties defined in elasticsearch and causes error. the Property were renamed.