### PR TITLE
spot link dotted border removed

### DIFF
--- a/Resources/Public/Theme/assets/css/main.css
+++ b/Resources/Public/Theme/assets/css/main.css
@@ -2172,6 +2172,9 @@ button:disabled,
     width: 100%;
     height: 100%;
     z-index: 999;
+    top: 0;
+    bottom: 0;
+    border: 0;
 }
 .spotlight .image {
     -moz-order: 1;


### PR DESCRIPTION
there was a dotted line around spotlight items and the link didn't cover the whole height of the element.